### PR TITLE
Fixes a merge issue with duplicating definitions.

### DIFF
--- a/Tuples/Tuple.cs
+++ b/Tuples/Tuple.cs
@@ -5,9 +5,7 @@ namespace CommonStructures {
     /// </summary>
     public struct Tuple {
 
-        /// <summary>
-        /// A utility function to create a pair.
-        /// </summary>
+        /// <summary> /// A utility function to create a pair.  /// </summary>
         public static Tuple<T1, T2> CreateTuple<T1, T2>(T1 item1, T2 item2) {
             return new Tuple<T1, T2>(item1, item2);
         }
@@ -200,22 +198,6 @@ namespace CommonStructures {
             this.item6 = item6;
             this.item7 = item7;
             this.item8 = item8;
-        }
-    }
-
-    public struct Tuple<T1, T2, T3> {
-        public readonly T1 item1;
-        public readonly T2 item2;
-        public readonly T3 item3;
-
-        public Tuple(T1 item1, T2 item2, T3 item3) {
-            this.item1 = item1;
-            this.item2 = item2;
-            this.item3 = item3;
-        }
-
-        public static Tuple<T1, T2, T3> CreateTuple(T1 item1, T2 item2, T3 item3) {
-            return new Tuple<T1, T2, T3>(item1, item2, item3);
         }
     }
 }


### PR DESCRIPTION
A merge from develop -> master determined that `Tuple<T1, T2, T3>` can be appended.
* This commit removes the duplication of the triple definition.